### PR TITLE
- Fixed a bug in JS8Call frequency hopping scheduler

### DIFF
--- a/SelfDestructMessageBox.cpp
+++ b/SelfDestructMessageBox.cpp
@@ -19,6 +19,8 @@ SelfDestructMessageBox::SelfDestructMessageBox(
 
     connect(&m_timer, &QTimer::timeout, this, &SelfDestructMessageBox::tick);
     m_timer.setInterval(1000);
+
+    connect(this->defaultButton(), &QPushButton::clicked, this, &SelfDestructMessageBox::accept);
 }
 
 void SelfDestructMessageBox::showEvent(QShowEvent* event)


### PR DESCRIPTION
- JS8Call 2.2.0 and 2.2.1-dev include a regression where no signal is sent at the close of the SelfDestructMessageBox to propagate the scheduled frequency change.

Line from previous version invoking connect() to establish Signal->Slot relationship reintroduced.
