### PR TITLE
Fixes for bug encountered when enabling autotx from on schedule.

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2173,6 +2173,8 @@ void MainWindow::tryBandHop(){
           connect(m, &SelfDestructMessageBox::accepted, this, [this, frequency,enable_autotx](){
               m_bandHopped = true;
               setRig(frequency);
+	      ui->extFreeTextMsgEdit->clear();
+	      clearCallsignSelected();
 	      ui->actionModeAutoreply->setChecked(enable_autotx);
               ui->hbMacroButton->setChecked(enable_autotx);
           });


### PR DESCRIPTION
- Tweaks to autotx transitions:
	- Any residual TX text is cleared
	- Any selected callsign is deselected